### PR TITLE
Specify supervisord config file to quiet warning. Refs #3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 ADD . /src/
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]


### PR DESCRIPTION
@jareddlc not really an actual problem per-say, but this will quiet one of the warning messages when running the container.
