### PR TITLE
Make coregi a global service by default

### DIFF
--- a/services/coregi.service
+++ b/services/coregi.service
@@ -15,3 +15,6 @@ ExecStart=/usr/bin/docker run --name coregi \
       -p 3000:3000 \
       speakit/coregi:latest
 ExecStop=/usr/bin/docker stop coregi
+
+[X-Fleet]
+Global=true


### PR DESCRIPTION
@jareddlc for our internal use, its convenient to have Coregi as a global service.  Maybe not everyone wants this.  I guess we could always rename coregi.service to coregi.service.example and people can tailor to their needs.
